### PR TITLE
Fixup semver check and fix some warnings

### DIFF
--- a/Bukkit/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
+++ b/Bukkit/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
@@ -55,15 +55,13 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 	}
 
 	@Override
-	public SpigetUpdate setUserAgent(String userAgent) {
+	public void setUserAgent(String userAgent) {
 		super.setUserAgent(userAgent);
-		return this;
 	}
 
 	@Override
-	public SpigetUpdate setVersionComparator(VersionComparator comparator) {
+	public void setVersionComparator(VersionComparator comparator) {
 		super.setVersionComparator(comparator);
-		return this;
 	}
 
 	@Override
@@ -100,7 +98,7 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 		final File updateFile = new File(updateFolder, pluginFile.getName());
 
 		Properties properties = getUpdaterProperties();
-		boolean allowExternalDownload = properties != null && properties.containsKey("externalDownloads") && Boolean.valueOf(properties.getProperty("externalDownloads"));
+		boolean allowExternalDownload = properties != null && properties.containsKey("externalDownloads") && Boolean.parseBoolean(properties.getProperty("externalDownloads"));
 
 		if (!allowExternalDownload && latestResourceInfo.external) {
 			failReason = DownloadFailReason.EXTERNAL_DISALLOWED;
@@ -172,7 +170,7 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 		NO_PLUGIN_FILE,
 		NO_UPDATE_FOLDER,
 		EXTERNAL_DISALLOWED,
-		UNKNOWN;
+		UNKNOWN
 	}
 
 }

--- a/Bukkit/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
+++ b/Bukkit/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
@@ -55,13 +55,15 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 	}
 
 	@Override
-	public void setUserAgent(String userAgent) {
+	public SpigetUpdate setUserAgent(String userAgent) {
 		super.setUserAgent(userAgent);
+		return this;
 	}
 
 	@Override
-	public void setVersionComparator(VersionComparator comparator) {
+	public SpigetUpdate setVersionComparator(VersionComparator comparator) {
 		super.setVersionComparator(comparator);
+		return this;
 	}
 
 	@Override

--- a/Bungee/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
+++ b/Bungee/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
@@ -43,15 +43,13 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 	}
 
 	@Override
-	public SpigetUpdate setUserAgent(String userAgent) {
+	public void setUserAgent(String userAgent) {
 		super.setUserAgent(userAgent);
-		return this;
 	}
 
 	@Override
-	public SpigetUpdate setVersionComparator(VersionComparator comparator) {
+	public void setVersionComparator(VersionComparator comparator) {
 		super.setVersionComparator(comparator);
-		return this;
 	}
 
 	@Override

--- a/Bungee/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
+++ b/Bungee/src/main/java/org/inventivetalent/update/spiget/SpigetUpdate.java
@@ -43,13 +43,15 @@ public class SpigetUpdate extends SpigetUpdateAbstract {
 	}
 
 	@Override
-	public void setUserAgent(String userAgent) {
+	public SpigetUpdate setUserAgent(String userAgent) {
 		super.setUserAgent(userAgent);
+		return this;
 	}
 
 	@Override
-	public void setVersionComparator(VersionComparator comparator) {
+	public SpigetUpdate setVersionComparator(VersionComparator comparator) {
 		super.setVersionComparator(comparator);
+		return this;
 	}
 
 	@Override

--- a/Core/src/main/java/org/inventivetalent/update/spiget/SpigetUpdateAbstract.java
+++ b/Core/src/main/java/org/inventivetalent/update/spiget/SpigetUpdateAbstract.java
@@ -58,16 +58,18 @@ public abstract class SpigetUpdateAbstract {
 		this.log = log;
 	}
 
-	public void setUserAgent(String userAgent) {
+	public SpigetUpdateAbstract setUserAgent(String userAgent) {
 		this.userAgent = userAgent;
+		return this;
 	}
 
 	public String getUserAgent() {
 		return userAgent;
 	}
 
-	public void setVersionComparator(VersionComparator comparator) {
+	public SpigetUpdateAbstract setVersionComparator(VersionComparator comparator) {
 		this.versionComparator = comparator;
+		return this;
 	}
 
 	public ResourceInfo getLatestResourceInfo() {

--- a/Core/src/main/java/org/inventivetalent/update/spiget/comparator/VersionComparator.java
+++ b/Core/src/main/java/org/inventivetalent/update/spiget/comparator/VersionComparator.java
@@ -28,6 +28,8 @@
 
 package org.inventivetalent.update.spiget.comparator;
 
+import java.util.Arrays;
+
 public abstract class VersionComparator {
 
 	/**
@@ -41,19 +43,33 @@ public abstract class VersionComparator {
 	};
 
 	/**
-	 * Compares versions by their Sematic Version (<code>Major.Minor.Patch</code>, <a href="http://semver.org/">semver.org</a>). Removes dots and compares the resulting Integer values
+	 * Compares versions by their Semantic Version (<code>Major.Minor.Patch</code>, <a href="http://semver.org/">semver.org</a>).
+	 * Parses major, minor and patch and goes down from major till patch to decide whether a version is newer.
+	 * Also supports longer variations like x.x.x.x or x.x. These cases will be handled properly.
 	 */
 	public static final VersionComparator SEM_VER = new VersionComparator() {
 		@Override
 		public boolean isNewer(String currentVersion, String checkVersion) {
-			currentVersion = currentVersion.replace(".", "");
-			checkVersion = checkVersion.replace(".", "");
-
 			try {
-				int current = Integer.parseInt(currentVersion);
-				int check = Integer.parseInt(checkVersion);
+				int[] currentVersionData = Arrays.stream(currentVersion.split("\\."))
+						.mapToInt(Integer::parseInt).toArray();
+				int[] checkVersionData = Arrays.stream(checkVersion.split("\\."))
+						.mapToInt(Integer::parseInt).toArray();
 
-				return check > current;
+				int i = 0;
+				for (int version : checkVersionData) {
+					if (i == currentVersionData.length) {
+						return true;
+					}
+
+					if (version > currentVersionData[i]) {
+						return true;
+					} else if (version < currentVersionData[i]) {
+						return false;
+					}
+
+					i++;
+				}
 			} catch (NumberFormatException e) {
 				System.err.println("[SpigetUpdate] Invalid SemVer versions specified [" + currentVersion + "] [" + checkVersion + "]");
 			}

--- a/Core/src/main/java/org/inventivetalent/update/spiget/download/UpdateDownloader.java
+++ b/Core/src/main/java/org/inventivetalent/update/spiget/download/UpdateDownloader.java
@@ -43,21 +43,14 @@ public class UpdateDownloader {
 	public static final String RESOURCE_DOWNLOAD = "http://api.spiget.org/v2/resources/%s/download";
 
 	public static Runnable downloadAsync(final ResourceInfo info, final File file, final String userAgent, final DownloadCallback callback) {
-		return new Runnable() {
-			@Override
-			public void run() {
-				try {
-					download(info, file, userAgent);
-					callback.finished();
-				} catch (Exception e) {
-					callback.error(e);
-				}
+		return () -> {
+			try {
+				download(info, file, userAgent);
+				callback.finished();
+			} catch (Exception e) {
+				callback.error(e);
 			}
 		};
-	}
-
-	public static void download(ResourceInfo info, File file) {
-		download(info, file);
 	}
 
 	public static void download(ResourceInfo info, File file, String userAgent) {

--- a/Core/src/test/java/org/inventivetalent/update/spiget/test/ComparatorTest.java
+++ b/Core/src/test/java/org/inventivetalent/update/spiget/test/ComparatorTest.java
@@ -1,0 +1,70 @@
+package org.inventivetalent.update.spiget.test;
+
+import org.inventivetalent.update.spiget.comparator.VersionComparator;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ComparatorTest {
+	@Test
+	public void equalsTest() {
+		String oldVersion = "1.0.0";
+		String newVersion = "2.0.0";
+
+		assertTrue(VersionComparator.EQUAL.isNewer(oldVersion, newVersion));
+
+		// This is a case where the simple equals check doesn't shine.
+		assertTrue(VersionComparator.EQUAL.isNewer(newVersion, oldVersion));
+
+		assertFalse(VersionComparator.EQUAL.isNewer(oldVersion, oldVersion));
+	}
+
+	@Test
+	public void semverTest() {
+		String oldVersion = "1.0.0";
+		String newVersion = "2.0.0";
+
+		assertTrue(VersionComparator.SEM_VER.isNewer(oldVersion, newVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(newVersion, oldVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(oldVersion, oldVersion));
+	}
+
+	@Test
+	public void longSemverTest() {
+		String oldVersion = "1.0";
+		String newVersion = "2.0.0.0.0.0";
+
+		assertTrue(VersionComparator.SEM_VER.isNewer(oldVersion, newVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(newVersion, oldVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(oldVersion, oldVersion));
+	}
+
+	@Test
+	public void longSemverTest2() {
+		String oldVersion = "5.0.6.2.7";
+		String newVersion = "6.0.7.3";
+
+		assertTrue(VersionComparator.SEM_VER.isNewer(oldVersion, newVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(newVersion, oldVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(oldVersion, oldVersion));
+	}
+
+	@Test
+	public void edgeSemverTest() {
+		String oldVersion = "1.1.10";
+		String newVersion = "1.2.0";
+
+		assertTrue(VersionComparator.SEM_VER.isNewer(oldVersion, newVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(newVersion, oldVersion));
+		assertFalse(VersionComparator.SEM_VER.isNewer(oldVersion, oldVersion));
+	}
+
+	@Test
+	public void semverSnapshotTest() {
+		String oldVersion = "1.0.0-SNAPSHOT";
+		String newVersion = "2.0.0-SNAPSHOT";
+
+		assertTrue(VersionComparator.SEM_VER_SNAPSHOT.isNewer(oldVersion, newVersion));
+		assertFalse(VersionComparator.SEM_VER_SNAPSHOT.isNewer(newVersion, oldVersion));
+		assertFalse(VersionComparator.SEM_VER_SNAPSHOT.isNewer(oldVersion, oldVersion));
+	}
+}

--- a/Core/src/test/java/org/inventivetalent/update/spiget/test/UpdateTest.java
+++ b/Core/src/test/java/org/inventivetalent/update/spiget/test/UpdateTest.java
@@ -6,14 +6,13 @@ import org.junit.Test;
 
 import java.util.logging.Logger;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class UpdateTest {
 
 	@Test
 	public void updateTest() {
-		SpigetUpdateAbstract updateCheck = new SpigetUpdateAbstract(5341/*NickNamer*/, "1.0.0", Logger.getLogger("UpdateTest")) {
+		SpigetUpdateAbstract updateCheck = new SpigetUpdateAbstract(5341/* NickNamer */, "1.0.0", Logger.getLogger("UpdateTest")) {
 			@Override
 			protected void dispatch(Runnable runnable) {
 				runnable.run();
@@ -32,7 +31,7 @@ public class UpdateTest {
 			public void upToDate() {
 				System.out.println("up-to-date");
 
-				assertTrue("Resource is up-to-date, but should have an update", false);
+				fail("Resource is up-to-date, but should have an update");
 			}
 		});
 	}


### PR DESCRIPTION
Changes include:
* Very dynamic semver system that replaces the faulty old check
* Removed one useless recursive method that just calls itself
* Remove builder pattern on a getter setter type of class. Builder pattern was never made use of anyway.
* Replace runnable creations with lambdas
* Use parser of newer gson
* Edit test a bit
* Add comparator tests